### PR TITLE
Remove NGINX https redirect and some minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The approach follows that of the book "Secure by Design":
 
 https://www.manning.com/books/secure-by-design
 
-The repo also contains a token seervice for demo and education purposes built with Duende Identity Server:
+The repo also contains a token service for demo and education purposes built with Duende Identity Server:
 
 https://github.com/DuendeSoftware/IdentityServer
 

--- a/requests.http
+++ b/requests.http
@@ -1,8 +1,8 @@
-// returns 401
+// Demo 2 returns 401
 GET https://localhost:5001/api/products/test
 
 
-// get token
+// Get token
 ###
 # @name token
 POST https://localhost:4000/connect/token HTTP/1.1
@@ -14,7 +14,7 @@ grant_type=client_credentials
 &client_id=m2m
 &client_secret=secret
 
-// returns 200
+// Returns 200
 ###
 GET https://localhost:5001/api/products/test
 content-type: application/json

--- a/rest-api/1-request-validation/nginx.conf
+++ b/rest-api/1-request-validation/nginx.conf
@@ -1,9 +1,4 @@
 # Conceptual NGNIX configuration 
-server {
-    listen 80;
-    server_name example.com;
-    return 301 https://example.com;
-}
 
 server {
     listen        443 ssl;

--- a/rest-api/3-token-transformation/ClaimsTransformation.cs
+++ b/rest-api/3-token-transformation/ClaimsTransformation.cs
@@ -17,15 +17,17 @@ namespace Defence.In.Depth
 
                 // This sample will just add hard-coded claims to any authenticated
                 // user, but a real example would of course instead use a local
-                // account database to get information about what organization and
+                // account database or external service to get information about 
                 // local permissions to add.
+                // Note that in this demo we represent permissions as claims, but in 
+                // demo 7 (and 9) we move to a permissions service.
 
                 // It is important to honor any scope that affect our domain
                 AddPermissionIfScope(identity, "products.read",  new Claim("urn:permission:product:read",  "true"));
                 AddPermissionIfScope(identity, "products.write", new Claim("urn:permission:product:write", "true"));
 
-                // Example claim that is not affected by scope
-                identity.AddClaim(new Claim("urn:identity:market", "se"));
+                // Example claim that is related to identity (the sub claim), not scopes.
+                identity.AddClaim(new Claim("urn:permission:market", "se"));
 
                 return new ClaimsPrincipal(identity);
             }

--- a/rest-api/4-input-data-validation/ClaimsTransformation.cs
+++ b/rest-api/4-input-data-validation/ClaimsTransformation.cs
@@ -17,15 +17,17 @@ namespace Defence.In.Depth
 
                 // This sample will just add hard-coded claims to any authenticated
                 // user, but a real example would of course instead use a local
-                // account database to get information about what organization and
-                // local permissions to add.
+                // account database or external service to get information about 
+                // what organization and local permissions to add.
+                // Note that in this demo we represent permissions as claims, but in 
+                // demo 7 (and 9) we move to a permissions service.
 
                 // It is important to honor any scope that affect our domain
                 AddPermissionIfScope(identity, "products.read",  new Claim("urn:permission:product:read",  "true"));
                 AddPermissionIfScope(identity, "products.write", new Claim("urn:permission:product:write", "true"));
 
-                // Example claim that is not affected by scope
-                identity.AddClaim(new Claim("urn:identity:market", "se"));
+                // Example claim that is related to identity (the sub claim), not scopes.
+                identity.AddClaim(new Claim("urn:permission:market", "se"));
 
                 return new ClaimsPrincipal(identity);
             }

--- a/rest-api/5-operation-validation/ClaimsTransformation.cs
+++ b/rest-api/5-operation-validation/ClaimsTransformation.cs
@@ -17,15 +17,17 @@ namespace Defence.In.Depth
 
                 // This sample will just add hard-coded claims to any authenticated
                 // user, but a real example would of course instead use a local
-                // account database to get information about what organization and
-                // local permissions to add.
+                // account database or external service to get information about 
+                // what organization and local permissions to add.
+                // Note that in this demo we represent permissions as claims, but in 
+                // demo 7 (and 9) we move to a permissions service.
 
                 // It is important to honor any scope that affect our domain
                 AddPermissionIfScope(identity, "products.read",  new Claim("urn:permission:product:read",  "true"));
                 AddPermissionIfScope(identity, "products.write", new Claim("urn:permission:product:write", "true"));
 
-                // Example claim that is not affected by scope
-                identity.AddClaim(new Claim("urn:identity:market", "se"));
+                // Example claim that is related to identity (the sub claim), not scopes.
+                identity.AddClaim(new Claim("urn:permission:market", "se"));
 
                 return new ClaimsPrincipal(identity);
             }

--- a/rest-api/6-data-access-validation/ClaimsTransformation.cs
+++ b/rest-api/6-data-access-validation/ClaimsTransformation.cs
@@ -17,15 +17,17 @@ namespace Defence.In.Depth
 
                 // This sample will just add hard-coded claims to any authenticated
                 // user, but a real example would of course instead use a local
-                // account database to get information about what organization and
-                // local permissions to add.
+                // account database or external service to get information about 
+                // what organization and local permissions to add.
+                // Note that in this demo we represent permissions as claims, but in 
+                // demo 7 (and 9) we move to a permissions service.
 
                 // It is important to honor any scope that affect our domain
                 AddPermissionIfScope(identity, "products.read",  new Claim("urn:permission:product:read",  "true"));
                 AddPermissionIfScope(identity, "products.write", new Claim("urn:permission:product:write", "true"));
 
-                // Example claim that is not affected by scope
-                identity.AddClaim(new Claim("urn:identity:market", "se"));
+                // Example claim that is related to identity (the sub claim), not scopes.
+                identity.AddClaim(new Claim("urn:permission:market", "se"));
 
                 return new ClaimsPrincipal(identity);
             }

--- a/rest-api/6-data-access-validation/Controllers/ProductsController.cs
+++ b/rest-api/6-data-access-validation/Controllers/ProductsController.cs
@@ -26,7 +26,7 @@ namespace Defence.In.Depth.Controllers
             var product = new { Name = "product", Market = "se" };            
 
             if (User.HasClaim(claim => 
-                    claim.Type == "urn:identity:market" && 
+                    claim.Type == "urn:permission:market" && 
                     claim.Value == product.Market))
             {
                 return Ok(product);

--- a/rest-api/7-secure-by-design/ClaimsTransformation.cs
+++ b/rest-api/7-secure-by-design/ClaimsTransformation.cs
@@ -14,11 +14,13 @@ namespace Defence.In.Depth
             {
                 var identity = new ClaimsIdentity(principal.Identity);
 
-                // There is a balance between this class and PermissionService.  As a
-                // general rule of thumb, limit this class to only deal with identity.
-                // Adding a claim for which market a user belongs to might belong here.
+                // There is a balance between this class and the PermissionService. As a
+                // general rule of thumb, limit this class to only deal with identity and
+                // only map (transform) claims to fit our domain and logic in the PermissionService.
+                // Adding additional claims might belong here, but external calls probaly should be
+                // made from the PermissionService. In this demo we add a claim for which market 
+                // a user belongs to.  
                 identity.AddClaim(new Claim("urn:identity:market", "se"));
-
                 return new ClaimsPrincipal(identity);
             }
 

--- a/rest-api/7-secure-by-design/Domain/Services/HttpContextPermissionService.cs
+++ b/rest-api/7-secure-by-design/Domain/Services/HttpContextPermissionService.cs
@@ -20,15 +20,17 @@ namespace Defence.In.Depth.Domain.Services
                 
                 throw new ArgumentException("User object is null", nameof(contextAccessor));
             }
-            
+
             // It is important to honor any scope that affect our domain
             IfScope(principal, "products.read", () => CanReadProducts = true);
             IfScope(principal, "products.write", () => CanWriteProducts = true);
 
-            // There is a balance between this class and ClaimsTransformation.  In
-            // our case, which market a user belongs to is added in
+            // There is a balance between this class and ClaimsTransformation. In
+            // our case, which market a user belongs to could be added in
             // ClaimsTransformation, but you might find that that kind of code is
-            // better placed here, inside your domain.
+            // better placed here, inside your domain, espacially if it requeries an
+            // external lookup. In real world scenarios we would most likely lookup
+            // market information etc given the identity.
             var market = principal.FindFirstValue("urn:identity:market");
             
             MarketId = new MarketId(market);

--- a/rest-api/9-complete-with-all-defence-layers/ClaimsTransformation.cs
+++ b/rest-api/9-complete-with-all-defence-layers/ClaimsTransformation.cs
@@ -14,11 +14,13 @@ namespace Defence.In.Depth
             {
                 var identity = new ClaimsIdentity(principal.Identity);
 
-                // There is a balance between this class and PermissionService.  As a
-                // general rule of thumb, limit this class to only deal with identity.
-                // Adding a claim for which market a user belongs to might belong here.
+                // There is a balance between this class and the PermissionService. As a
+                // general rule of thumb, limit this class to only deal with identity and
+                // only map (transform) claims to fit our domain and logic in the PermissionService.
+                // Adding additional claims might belong here, but external calls probaly should be
+                // made from the PermissionService. In this demo we add a claim for which market 
+                // a user belongs to.  
                 identity.AddClaim(new Claim("urn:identity:market", "se"));
-
                 return new ClaimsPrincipal(identity);
             }
 

--- a/rest-api/9-complete-with-all-defence-layers/Domain/Services/HttpContextPermissionService.cs
+++ b/rest-api/9-complete-with-all-defence-layers/Domain/Services/HttpContextPermissionService.cs
@@ -25,10 +25,12 @@ namespace Defence.In.Depth.Domain.Services
             IfScope(principal, "products.read", () => CanReadProducts = true);
             IfScope(principal, "products.write", () => CanWriteProducts = true);
 
-            // There is a balance between this class and ClaimsTransformation.  In
-            // our case, which market a user belongs to is added in
+            // There is a balance between this class and ClaimsTransformation. In
+            // our case, which market a user belongs to could be added in
             // ClaimsTransformation, but you might find that that kind of code is
-            // better placed here, inside your domain.
+            // better placed here, inside your domain, espacially if it requeries an
+            // external lookup. In real world scenarios we would most likely lookup
+            // market information etc given the identity.
             var market = principal.FindFirstValue("urn:identity:market");
             
             MarketId = new MarketId(market);

--- a/rest-api/9-complete-with-all-defence-layers/Program.cs
+++ b/rest-api/9-complete-with-all-defence-layers/Program.cs
@@ -20,7 +20,7 @@ namespace Defence.In.Depth
                 // On e g Linux it will be hosted out-of process in Kestrel, and you need a reverse proxy like NGINX in front
                 .CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder => webBuilder
-                    // DEMO 8 - Handle secretes using App Configuration and Key Vault
+                    // Demo 8 - Handle secretes using App Configuration and Key Vault
                     // Note that MSI needs to be set up and secretes needs to refrence key vault
                     // https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
                    .ConfigureAppConfiguration((hostingContext, config) =>

--- a/rest-api/9-complete-with-all-defence-layers/nginx.conf
+++ b/rest-api/9-complete-with-all-defence-layers/nginx.conf
@@ -1,9 +1,4 @@
 # Conceptual NGNIX configuration 
-server {
-    listen 80;
-    server_name example.com;
-    return 301 https://example.com;
-}
 
 server {
     listen        443 ssl;

--- a/rest-api/README.md
+++ b/rest-api/README.md
@@ -1,5 +1,5 @@
 This repo demonstrates the patterns and concepts for REST APIs from 
-https://omegapoint.se/applikationssakerhet-forsvar-pa-djupet-start
+https://omegapoint.se/defence-in-depth-secure-apis
 
 DEMO:
 1. Validate request


### PR DESCRIPTION
This repo demonstrates a small backend API, normally there is no need to redirect from http to https when hosting this kind of API (redirect is recommended for user applications). So the redirect code is removed and the host only accepts https on 443.

Also some minor cleanup in readme and comments in the requests file.  