### PR TITLE
Use domain classes in repository interfaces

### DIFF
--- a/rest-api/7-secure-by-design/Domain/Services/ProductService.cs
+++ b/rest-api/7-secure-by-design/Domain/Services/ProductService.cs
@@ -1,4 +1,3 @@
-using AutoMapper;
 using Defence.In.Depth.Domain.Models;
 using Defence.In.Depth.Infrastructure;
 
@@ -9,18 +8,15 @@ public class ProductService : IProductService
     private readonly IPermissionService permissionService;
     private readonly IProductRepository productRepository;
     private readonly IAuditService auditService;
-    private readonly IMapper mapper;
 
     public ProductService(
         IPermissionService permissionService,
         IProductRepository productRepository,
-        IAuditService auditService,
-        IMapper mapper)
+        IAuditService auditService)
     {
         this.permissionService = permissionService;
         this.productRepository = productRepository;
         this.auditService = auditService;
-        this.mapper = mapper;
     }
 
     public async Task<(Product? product, ReadDataResult result)> GetById(ProductId productId)
@@ -32,15 +28,13 @@ public class ProductService : IProductService
             return (null, ReadDataResult.NoAccessToOperation);
         }
 
-        var entity = await productRepository.GetById(productId.Value);
+        var product = await productRepository.GetById(productId);
 
-        if (entity == null)
+        if (product == null)
         {
             return (null, ReadDataResult.NotFound);
         }
 
-        var product = mapper.Map<Product>(entity);
-            
         if (!permissionService.HasPermissionToMarket(product.MarketId))
         {
             await auditService.Log(DomainEvent.NoAccessToData, productId);

--- a/rest-api/7-secure-by-design/Infrastructure/IProductRepository.cs
+++ b/rest-api/7-secure-by-design/Infrastructure/IProductRepository.cs
@@ -1,8 +1,8 @@
-using Defence.In.Depth.Infrastructure.Entities;
+using Defence.In.Depth.Domain.Models;
 
 namespace Defence.In.Depth.Infrastructure;
 
 public interface IProductRepository
 {
-    Task<ProductEntity> GetById(string id);
+    Task<Product> GetById(ProductId productId);
 }

--- a/rest-api/7-secure-by-design/Infrastructure/ProductRepository.cs
+++ b/rest-api/7-secure-by-design/Infrastructure/ProductRepository.cs
@@ -1,16 +1,25 @@
+using AutoMapper;
+using Defence.In.Depth.Domain.Models;
 using Defence.In.Depth.Infrastructure.Entities;
 
 namespace Defence.In.Depth.Infrastructure;
 
 public class ProductRepository : IProductRepository
 {
-    public async Task<ProductEntity> GetById(string id)
+    private readonly IMapper mapper;
+
+    public ProductRepository(IMapper mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    public async Task<Product> GetById(ProductId productId)
     {
         await Task.CompletedTask;
-            
-        // Please always use correct output encoding of input data "id" for
-        // your query context. For example, parameterized SQL.
-        // Here we have just hardcoded the id to the input.
-        return new ProductEntity { Id = id, Name = "ProductSweden", MarketId = "se" };
+
+        // We just create an entity, but normally this is a database query
+        var entity = new ProductEntity { Id = productId.Value, Name = "Product in Sweden", MarketId = "se" };
+
+        return mapper.Map<Product>(entity);
     }
 }

--- a/rest-api/9-complete-with-all-defence-layers/Domain/Services/ProductService.cs
+++ b/rest-api/9-complete-with-all-defence-layers/Domain/Services/ProductService.cs
@@ -9,18 +9,15 @@ public class ProductService : IProductService
     private readonly IPermissionService permissionService;
     private readonly IProductRepository productRepository;
     private readonly IAuditService auditService;
-    private readonly IMapper mapper;
-
+ 
     public ProductService(
         IPermissionService permissionService,
         IProductRepository productRepository,
-        IAuditService auditService,
-        IMapper mapper)
+        IAuditService auditService)
     {
         this.permissionService = permissionService;
         this.productRepository = productRepository;
         this.auditService = auditService;
-        this.mapper = mapper;
     }
 
     // Note that in a real world domain, with more services and methods, it is important to
@@ -38,15 +35,13 @@ public class ProductService : IProductService
             return (null, ReadDataResult.NoAccessToOperation);
         }
 
-        var entity = await productRepository.GetById(productId.Value);
+        var product = await productRepository.GetById(productId);
 
-        if (entity.Id == null)
+        if (product == null)
         {
             return (null, ReadDataResult.NotFound);
         }
 
-        var product = mapper.Map<Product>(entity);
-            
         if (!permissionService.HasPermissionToMarket(product.MarketId))
         {
             await auditService.Log(DomainEvent.NoAccessToData, productId);
@@ -55,7 +50,7 @@ public class ProductService : IProductService
         }
        
         // When we have access to the specific product we can do more complex logic,
-        // like finding out if it is availible in stores etc.
+        // like finding out if it is available in stores etc.
 
         await auditService.Log(DomainEvent.ProductRead, productId);
 

--- a/rest-api/9-complete-with-all-defence-layers/Infrastructure/IProductRepository.cs
+++ b/rest-api/9-complete-with-all-defence-layers/Infrastructure/IProductRepository.cs
@@ -1,8 +1,8 @@
-using Defence.In.Depth.Infrastructure.Entities;
+using Defence.In.Depth.Domain.Models;
 
 namespace Defence.In.Depth.Infrastructure;
 
 public interface IProductRepository
 {
-    Task<ProductEntity> GetById(string id);
+    Task<Product> GetById(ProductId productId);
 }

--- a/rest-api/9-complete-with-all-defence-layers/Infrastructure/ProductRepository.cs
+++ b/rest-api/9-complete-with-all-defence-layers/Infrastructure/ProductRepository.cs
@@ -1,25 +1,29 @@
+using AutoMapper;
+using Defence.In.Depth.Domain.Models;
 using Defence.In.Depth.Infrastructure.Entities;
 
 namespace Defence.In.Depth.Infrastructure;
 
 public class ProductRepository : IProductRepository
 {
-    private Dictionary<string, ProductEntity> _repo = new Dictionary<string, ProductEntity>{
+    private readonly IMapper mapper;
+
+    private readonly Dictionary<string, ProductEntity> data = new Dictionary<string, ProductEntity>{
         {"se1", new ProductEntity { Id = "se1", Name = "ProductSweden", MarketId = "se" }},
         {"no1", new ProductEntity { Id = "no1", Name = "ProductNorway", MarketId = "no" }}
     };
 
-    public async Task<ProductEntity> GetById(string id)
+    public ProductRepository(IMapper mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    public async Task<Product> GetById(ProductId productId)
     {
         await Task.CompletedTask;
             
-        // Please always use correct output encoding of input data "id" for
-        // your query context.  For example, parameterized SQL.
-        if(!_repo.ContainsKey(id))
-        {
-            return new ProductEntity();
-        }
+        var entity = data.GetValueOrDefault(productId.Value);
 
-        return _repo[id];
+        return mapper.Map<Product>(entity);
     }
 }

--- a/rest-api/tests/9-complete-with-all-defence-layers-tests/Tests.Unit/AutoMapperConfigurationTests.cs
+++ b/rest-api/tests/9-complete-with-all-defence-layers-tests/Tests.Unit/AutoMapperConfigurationTests.cs
@@ -1,0 +1,15 @@
+using AutoMapper;
+using Defence.In.Depth;
+using Xunit;
+
+namespace CompleteWithAllDefenceLayers.Tests.Unit;
+
+public class AutoMapperConfigurationTests
+{
+    [Fact]
+    public void AssertConfigurationIsValid()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        config.AssertConfigurationIsValid();
+    }    
+}

--- a/rest-api/tests/9-complete-with-all-defence-layers-tests/Tests.Unit/ProductsControllerTests.cs
+++ b/rest-api/tests/9-complete-with-all-defence-layers-tests/Tests.Unit/ProductsControllerTests.cs
@@ -1,3 +1,5 @@
+using AutoMapper;
+using Defence.In.Depth;
 using Defence.In.Depth.Controllers;
 using Defence.In.Depth.Domain.Models;
 using Defence.In.Depth.Domain.Services;
@@ -10,11 +12,13 @@ namespace CompleteWithAllDefenceLayers.Tests.Unit;
 [Trait("Category", "Unit")]
 public class ProductsControllerTests
 {
+    private readonly IMapper mapper = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>()).CreateMapper();
+
     [Fact]
     public async void GetProductsById_ShouldReturn403_WhenCanNotRead()
     {
-        var productServiceMock = new Mock<IProductService>();
-        productServiceMock.Setup(ps => ps.GetById(It.IsAny<ProductId>()))
+        var productService = Mock.Of<IProductService>();
+        Mock.Get(productService).Setup(ps => ps.GetById(It.IsAny<ProductId>()))
             .ReturnsAsync((
                 new Product(
                     new ProductId("se1"),
@@ -22,7 +26,7 @@ public class ProductsControllerTests
                     new MarketId("se")),
                 ReadDataResult.NoAccessToOperation));
 
-        var controller = new ProductsController(productServiceMock.Object, TestMapper.Create());
+        var controller = new ProductsController(productService, mapper);
 
         var result = await controller.GetById("se1");
 
@@ -32,8 +36,8 @@ public class ProductsControllerTests
     [Fact]
     public async void GetProductsById_ShouldReturn200_WhenAuthorized()
     {
-        var productServiceMock = new Mock<IProductService>();
-        productServiceMock.Setup(ps => ps.GetById(It.IsAny<ProductId>()))
+        var productService = Mock.Of<IProductService>();
+        Mock.Get(productService).Setup(ps => ps.GetById(It.IsAny<ProductId>()))
             .ReturnsAsync((
                     new Product(
                         new ProductId("se1"), 
@@ -41,7 +45,7 @@ public class ProductsControllerTests
                         new MarketId("se")),
                     ReadDataResult.Success));
 
-        var controller = new ProductsController(productServiceMock.Object, TestMapper.Create());
+        var controller = new ProductsController(productService, mapper);
 
         var result = await controller.GetById("se1");
 
@@ -53,8 +57,8 @@ public class ProductsControllerTests
     [MemberData(nameof(InvalidIds))]
     public async void GetProductsById_ShouldReturn400_WhenInvalidId(string id)
     {
-        var productServiceMock = new Mock<IProductService>();
-        productServiceMock.Setup(ps => ps.GetById(It.IsAny<ProductId>()))
+        var productService = Mock.Of<IProductService>();
+        Mock.Get(productService).Setup(ps => ps.GetById(It.IsAny<ProductId>()))
              .ReturnsAsync((
                  new Product(
                      new ProductId("se1"),
@@ -62,7 +66,7 @@ public class ProductsControllerTests
                      new MarketId("se")), 
                  ReadDataResult.Success));
 
-        var controller = new ProductsController(productServiceMock.Object, TestMapper.Create());
+        var controller = new ProductsController(productService, mapper);
 
         var result = await controller.GetById(id);
 
@@ -72,8 +76,8 @@ public class ProductsControllerTests
     [Fact]
     public async void GetProductsById_ShouldReturn404_WhenNotFound()
     {
-        var productServiceMock = new Mock<IProductService>();
-        productServiceMock.Setup(ps => ps.GetById(It.IsAny<ProductId>()))
+        var productService = Mock.Of<IProductService>();
+        Mock.Get(productService).Setup(ps => ps.GetById(It.IsAny<ProductId>()))
             .ReturnsAsync((
                 new Product(
                     new ProductId("se1"),
@@ -81,7 +85,7 @@ public class ProductsControllerTests
                     new MarketId("se")),
                 ReadDataResult.NotFound));
 
-        var controller = new ProductsController(productServiceMock.Object, TestMapper.Create());
+        var controller = new ProductsController(productService, mapper);
 
         var result = await controller.GetById("def"); // This is a valid, non-existing id
 


### PR DESCRIPTION
This commit will refactor the repository interfaces to work with domain objects instead of storage entity classes.  This means that the repository interfaces can be part of the domain.

This commit also cleans up all related test cases to take more advantage of Moq.